### PR TITLE
Ignore hijacked connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 before_install:
   - go get github.com/stretchr/testify
+  - go get golang.org/x/net/websocket
 go:
   - "1.10"
 script: go test

--- a/options.go
+++ b/options.go
@@ -5,7 +5,6 @@ type Options struct {
 	statusCode *int
 	size       int
 	recorder   ResponseWriter
-	saveResult bool
 }
 
 // StatusCode returns the response status code.
@@ -47,13 +46,6 @@ func WithSize(size int) Option {
 func WithRecorder(recorder ResponseWriter) Option {
 	return func(o *Options) {
 		o.recorder = recorder
-	}
-}
-
-// WithRecorder sets the recorder to use in stats.
-func WithSaveResult(save bool) Option {
-	return func(o *Options) {
-		o.saveResult = save
 	}
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -4,10 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"golang.org/x/net/websocket"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,8 +28,8 @@ func TestSimple(t *testing.T) {
 
 	s.Handler(testHandler).ServeHTTP(res, req)
 
-	assert.Equal(t, res.Code, 200)
-	assert.Equal(t, s.ResponseCounts, map[string]int{"200": 1})
+	assert.Equal(t, 200, res.Code)
+	assert.Equal(t, map[string]int{"200": 1}, s.ResponseCounts)
 }
 
 func TestGetStats(t *testing.T) {
@@ -52,7 +56,7 @@ func TestGetStats(t *testing.T) {
 
 	s.Handler(stats).ServeHTTP(res, req)
 
-	assert.Equal(t, res.Header().Get("Content-Type"), "application/json")
+	assert.Equal(t, "application/json", res.Header().Get("Content-Type"))
 
 	var data map[string]interface{}
 
@@ -60,7 +64,7 @@ func TestGetStats(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, data["total_count"].(float64), float64(1))
+	assert.Equal(t, float64(1), data["total_count"].(float64))
 }
 
 func TestRace(t *testing.T) {
@@ -99,4 +103,54 @@ func TestRace(t *testing.T) {
 
 	ch1 <- true
 	ch2 <- true
+}
+
+func TestWebsocketIgnore(t *testing.T) {
+	s := New()
+	handler := websocket.Handler(func(conn *websocket.Conn) {
+		conn.Write([]byte("TEST"))
+	})
+
+	srv := httptest.NewServer(s.Handler(handler))
+
+	url := strings.Replace(srv.URL, "http", "ws", 1)
+	ws, err := websocket.Dial(url, "", srv.URL)
+	require.NoError(t, err)
+
+	bytes := make([]byte, 255)
+	n, err := ws.Read(bytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "TEST", string(bytes[:n]))
+	assert.Equal(t, map[string]int{}, s.ResponseCounts)
+
+}
+
+func TestWebsocketErrorNotIgnore(t *testing.T) {
+	s := New()
+
+	srv := httptest.NewServer(s.Handler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+	})))
+
+	url := strings.Replace(srv.URL, "http", "ws", 1)
+	_, err := websocket.Dial(url, "", srv.URL)
+	require.Error(t, err)
+
+	assert.Equal(t, map[string]int{"500": 1}, s.ResponseCounts)
+
+}
+
+func TestIgnoreHijackedConnection(t *testing.T) {
+	s := New()
+
+	res := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.Handler(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.(http.Hijacker).Hijack()
+	})).ServeHTTP(res, req)
+
+	assert.Equal(t, map[string]int{}, s.ResponseCounts)
 }


### PR DESCRIPTION
Hijacked connections can remain open for a long time (Websocket for example) and generate a wrong response time in the statistics.

Prior to this PR, hijacked connections were considered status code 200.
With this PR, we ignore the hijacked connections.

In addition, we can remove the code specific to Websocket because Websocket is a hijacked connection.

And finally, it fixes a bug because, prior to this PR, Websocket upgrade failures were ignored.