### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/options.go
+++ b/options.go
@@ -50,7 +50,7 @@ func WithRecorder(recorder ResponseWriter) Option {
 	}
 }
 
-// WithRecorder sets the recorder to use in stats.
+// WithSaveResult: sets the recorder to use in stats.
 func WithSaveResult(save bool) Option {
 	return func(o *Options) {
 		o.saveResult = save

--- a/recorder.go
+++ b/recorder.go
@@ -60,7 +60,7 @@ func (r *recorderResponseWriter) Write(b []byte) (int, error) {
 	return size, err
 }
 
-// Proxy method to Status to add support for gocraft
+// StatusCode: Proxy method to Status to add support for gocraft
 func (r *recorderResponseWriter) StatusCode() int {
 	return r.Status()
 }

--- a/stats.go
+++ b/stats.go
@@ -84,7 +84,7 @@ func (mw *Stats) Handler(h http.Handler) http.Handler {
 	})
 }
 
-// Negroni compatible interface
+// ServeHTTP: Negroni compatible interface
 func (mw *Stats) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	beginning, recorder := mw.Begin(w)
 


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*